### PR TITLE
Amq 9359

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/StompWSConnection.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/StompWSConnection.java
@@ -25,20 +25,17 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.transport.stomp.StompFrame;
 import org.apache.activemq.transport.stomp.StompWireFormat;
-import org.eclipse.jetty.ee9.websocket.api.Session;
-import org.eclipse.jetty.ee9.websocket.api.WebSocketAdapter;
-import org.eclipse.jetty.ee9.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.api.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * STOMP over WS based Connection class
  */
-public class StompWSConnection extends WebSocketAdapter implements WebSocketListener {
+public class StompWSConnection extends org.eclipse.jetty.websocket.api.Session.Listener.AbstractAutoDemanding implements Session.Listener.AutoDemanding {
 
     private static final Logger LOG = LoggerFactory.getLogger(StompWSConnection.class);
 
-    private Session connection;
     private final CountDownLatch connectLatch = new CountDownLatch(1);
 
     private final BlockingQueue<String> prefetch = new LinkedBlockingDeque<String>();
@@ -47,36 +44,37 @@ public class StompWSConnection extends WebSocketAdapter implements WebSocketList
     private int closeCode = -1;
     private String closeMessage;
 
-    @Override
     public boolean isConnected() {
-        return connection != null ? connection.isOpen() : false;
+        Session session = getSession();
+        return session != null && session.isOpen();
     }
 
     public void close() {
-        if (connection != null) {
-            connection.close();
+        Session session = getSession();
+        if (session != null) {
+            session.close();
         }
     }
 
     protected Session getConnection() {
-        return connection;
+        return getSession();
     }
 
     //---- Send methods ------------------------------------------------------//
 
     public synchronized void sendRawFrame(String rawFrame) throws Exception {
         checkConnected();
-        connection.getRemote().sendString(rawFrame);
+        getSession().sendText(rawFrame, null);
     }
 
     public synchronized void sendFrame(StompFrame frame) throws Exception {
         checkConnected();
-        connection.getRemote().sendString(wireFormat.marshalToString(frame));
+        getSession().sendText(wireFormat.marshalToString(frame), null);
     }
 
     public synchronized void keepAlive() throws Exception {
         checkConnected();
-        connection.getRemote().sendString("\n");
+        getSession().sendText("\n", null);
     }
 
     //----- Receive methods --------------------------------------------------//
@@ -136,22 +134,21 @@ public class StompWSConnection extends WebSocketAdapter implements WebSocketList
     public void onWebSocketClose(int statusCode, String reason) {
         LOG.trace("STOMP WS Connection closed, code:{} message:{}", statusCode, reason);
 
-        this.connection = null;
         this.closeCode = statusCode;
         this.closeMessage = reason;
     }
 
     @Override
-    public void onWebSocketConnect(org.eclipse.jetty.ee9.websocket.api.Session session) {
-        this.connection = session;
-        this.connection.setIdleTimeout(Duration.ZERO);
+    public void onWebSocketOpen(Session session) {
+        super.onWebSocketOpen(session);
+        session.setIdleTimeout(Duration.ZERO);
         this.connectLatch.countDown();
     }
 
     //----- Internal implementation ------------------------------------------//
 
     private void checkConnected() throws IOException {
-        if (!isConnected()) {
+        if (!isOpen()) {
             throw new IOException("STOMP WS Connection is closed.");
         }
     }

--- a/activemq-web-console/pom.xml
+++ b/activemq-web-console/pom.xml
@@ -52,20 +52,18 @@
         </configuration>
       </plugin>
       <plugin>
-          <groupId>${jetty.maven.groupid}</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee9</groupId>
+        <artifactId>jetty-ee9-maven-plugin</artifactId>
         <version>${jetty-version}</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.eclipse.jetty.server.ServerConnector">
-              <port>${jetty.port}</port>
-              <maxIdleTime>60000</maxIdleTime>
-            </connector>
-          </connectors>
-
-          <webAppConfig>
+          <httpConnector>
+            <port>${jetty.port}</port>
+            <idleTimeout>60000</idleTimeout>
+          </httpConnector>
+          <scan>10</scan>
+          <webApp>
             <contextPath>/</contextPath>
-          </webAppConfig>
+          </webApp>
 
           <systemProperties>
             <!-- enable easy connection to JConsole -->
@@ -100,7 +98,6 @@
                         </systemProperty>
             -->
           </systemProperties>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
         </configuration>
       </plugin>
       <plugin>
@@ -288,18 +285,24 @@
       <scope>provided</scope>
     </dependency>
     
-     <!-- Tag Libs -->
+    <!-- Tag Libs -->
+    <!--
+      These two should be available either in the WAR itself or from the container. We can't configure
+      jetty-ee9-maven-plugin with <useProvidedScope>true</useProvidedScope> because we don't need ALL provided
+      dependencies. But we shouldn't build the WAR with these two included either, because _full_ web container
+      may provide own taglibs... Not me to decide ;)
+    -->
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
       <version>3.0.0</version>
-      <scope>provided</scope>
+<!--      <scope>provided</scope>-->
     </dependency>
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>jakarta.servlet.jsp.jstl</artifactId>
       <version>3.0.1</version>
-      <scope>provided</scope>
+<!--      <scope>provided</scope>-->
     </dependency>
     <!--
     <dependency>

--- a/activemq-web-demo/pom.xml
+++ b/activemq-web-demo/pom.xml
@@ -33,16 +33,15 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee9</groupId>
+        <artifactId>jetty-ee9-maven-plugin</artifactId>
         <configuration>
-          <connectors>
-            <connector implementation="org.eclipse.jetty.server.ServerConnector">
-              <port>${jetty.port}</port>
-              <maxIdleTime>60000</maxIdleTime>
-            </connector>
-          </connectors>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <httpConnector>
+            <port>${jetty.port}</port>
+            <idleTimeout>60000</idleTimeout>
+          </httpConnector>
+          <scan>10</scan>
+          <useTestScope>true</useTestScope>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1048,8 +1048,8 @@
           <version>${javacc-maven-plugin-version}</version>
         </plugin>
         <plugin>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
+          <groupId>org.eclipse.jetty.ee9</groupId>
+          <artifactId>jetty-ee9-maven-plugin</artifactId>
           <version>${jetty-version}</version>
         </plugin>
         <plugin>


### PR DESCRIPTION
@mattrpav here's my idea about moving `org.apache.activemq.transport.ws.StompWSConnection` to Jetty 12.
Generally it's about switching parent class and implemented interface to new one according to https://jetty.org/docs/jetty/12/programming-guide/client/websocket.html

You shouldn't use `org.eclipse.jetty.ee9.websocket.api.WebSocketListener` as it's for "Jakarta" Websocket API 2.0 (or ee10, which is Websocket API 2.1). See https://jetty.org/docs/jetty/12/programming-guide/server/websocket.html

You should use _native_ Jetty websocket as it was before. So you should implement one of these (no idea about _autodemand_):
* `org.eclipse.jetty.websocket.api.Session.Listener`
* `org.eclipse.jetty.websocket.api.Session.Listener.AutoDemanding`

In this PR I did it with `org.apache.activemq.transport.ws.StompWSConnection` and `org.apache.activemq.transport.ws.StompWSTransportTest` test started to pass.

But I didn't touch these:
* `org.apache.activemq.transport.ws.WSTransportProxy`
* `org.apache.activemq.transport.ws.jetty12.MQTTSocket`
* `org.apache.activemq.transport.ws.jetty12.StompSocket`
* `org.apache.activemq.transport.ws.MQTTWSConnection`

which still implement `org.eclipse.jetty.ee9.websocket.api.WebSocketListener`.

I hope this is enough for you to proceed with Jetty 12.